### PR TITLE
Treating RxInvokerProvider as any other provider.

### DIFF
--- a/examples/src/main/java/jaxrs/examples/client/webdav/WebDavTargetedBuilder.java
+++ b/examples/src/main/java/jaxrs/examples/client/webdav/WebDavTargetedBuilder.java
@@ -49,7 +49,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.NioInvoker;
 import javax.ws.rs.client.RxInvoker;
-import javax.ws.rs.client.RxInvokerProvider;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.GenericType;
@@ -290,31 +289,21 @@ public class WebDavTargetedBuilder implements Invocation.Builder, WebDavSyncInvo
 
     @Override
     public CompletionStageRxInvoker rx() {
-        return null;
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public CompletionStageRxInvoker rx(ExecutorService executorService) {
-        return null;
-    }
-
-    @Override
-    public <T extends RxInvoker> T rx(RxInvokerProvider<T> rxInvokerProvider) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public <T extends RxInvoker> T rx(Class<? extends RxInvokerProvider<T>> clazz) {
+    public <T extends RxInvoker> T rx(Class<T> clazz) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public <T extends RxInvoker> T rx(RxInvokerProvider<T> rxInvokerProvider, ExecutorService executorService) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
-    public <T extends RxInvoker> T rx(Class<? extends RxInvokerProvider<T>> clazz, ExecutorService executorService) {
+    public <T extends RxInvoker> T rx(Class<T> clazz, ExecutorService executorService) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/Invocation.java
@@ -313,62 +313,40 @@ public interface Invocation {
         public CompletionStageRxInvoker rx(ExecutorService executorService);
 
         /**
-         * Access a reactive invoker based on an implementation of {@link RxInvokerProvider}
-         * provided. This method is an extension point for JAX-RS implementations to support other types
+         * Access a reactive invoker based on provider {@link RxInvoker} subclass. Note
+         * that corresponding {@link RxInvokerProvider} must be registered to client runtime.
+         * <p>
+         * This method is an extension point for JAX-RS implementations to support other types
          * representing asynchronous computations.
          *
-         * @param rxInvokerProvider {@link RxInvoker} subclass provider instance.
+         * @param clazz {@link RxInvoker} subclass.
          * @return reactive invoker instance.
+         * @throws IllegalStateException when provider for given class is not registered.
+         * @see javax.ws.rs.client.Invocation.Builder#rx(Class, ExecutorService)
+         * @see javax.ws.rs.client.Client#register(Class)
          * @since 2.1
-         * @see javax.ws.rs.client.Invocation.Builder#rx(RxInvokerProvider, ExecutorService)
          */
-        public <T extends RxInvoker> T rx(RxInvokerProvider<T> rxInvokerProvider);
+        public <T extends RxInvoker> T rx(Class<T> clazz);
 
         /**
-         * Access a reactive invoker based on an implementation of {@link RxInvokerProvider}
-         * provided. This method is an extension point for JAX-RS implementations to support other types
-         * representing asynchronous computations.
-         *
-         * @param clazz {@link RxInvoker} subclass provider class.
-         * @return reactive invoker instance.
-         * @since 2.1
-         * @see javax.ws.rs.client.Invocation.Builder#rx(RxInvokerProvider, ExecutorService)
-         */
-        public <T extends RxInvoker> T rx(Class<? extends RxInvokerProvider<T>> clazz);
-
-        /**
-         * Access a reactive invoker based on an implementation of {@link RxInvokerProvider}
-         * and the executor service provided. This method is an extension point for JAX-RS implementations
+         * Access a reactive invoker based on provider {@link RxInvoker} subclass. Note
+         * that corresponding {@link RxInvokerProvider} must be registered to client runtime.
+         * <p>
+         * This method is an extension point for JAX-RS implementations
          * to support other types representing asynchronous computations. Note that not
          * all executor services are supported in all runtime environments. For example, only
          * executor services provided by JSR 236 should be supported in a Java EE environment.
          *
-         * @param rxInvokerProvider {@link RxInvoker} subclass provider instance.
+         * @param clazz           {@link RxInvoker} subclass provider class.
          * @param executorService executor service to use.
-         * @throws java.lang.IllegalArgumentException if the executor service provided is not
-         *                                            supported by the runtime environment.
-         * @return default reactive invoker instance.
-         * @since 2.1
-         * @see javax.ws.rs.client.Invocation.Builder#rx()
-         */
-        public <T extends RxInvoker> T rx(RxInvokerProvider<T> rxInvokerProvider, ExecutorService executorService);
-
-        /**
-         * Access a reactive invoker based on an implementation of {@link RxInvokerProvider}
-         * and the executor service provided. This method is an extension point for JAX-RS implementations
-         * to support other types representing asynchronous computations. Note that not
-         * all executor services are supported in all runtime environments. For example, only
-         * executor services provided by JSR 236 should be supported in a Java EE environment.
-         *
-         * @param clazz {@link RxInvoker} subclass provider class.
-         * @param executorService executor service to use.
-         * @throws java.lang.IllegalArgumentException if the executor service provided is not
-         *                                            supported by the runtime environment.
          * @return default reactive invoker instance class.
-         * @since 2.1
+         * @throws java.lang.IllegalArgumentException if the executor service provided is not
+         *                                            supported by the runtime environment.
+         * @throws IllegalStateException              when provider for given class is not registered.
          * @see javax.ws.rs.client.Invocation.Builder#rx()
+         * @since 2.1
          */
-        public <T extends RxInvoker> T rx(Class<? extends RxInvokerProvider<T>> clazz, ExecutorService executorService);
+        public <T extends RxInvoker> T rx(Class<T> clazz, ExecutorService executorService);
 
         /**
          * Access the NIO uniform request invocation interface to use non-blocking I/O

--- a/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvokerProvider.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/client/RxInvokerProvider.java
@@ -52,16 +52,24 @@ import java.util.concurrent.ExecutorService;
 public interface RxInvokerProvider<T extends RxInvoker> {
 
     /**
+     * Find out whether current instance provides given {@link RxInvoker} subclass.
+     *
+     * @param clazz {@code RxInvoker} subclass.
+     * @return {@code true} when this provider provides given {@code RxInvoker} subclass, {@code false} otherwise.
+     */
+    public boolean isProviderFor(Class<?> clazz);
+
+    /**
      * Get {@link RxInvoker} implementation instance.
      * <p>
      * The returned instance has to be thread safe.
      *
-     * @param invocationBuilder {@code Invocation.Builder} from the previous stage of client builder.
+     * @param syncInvoker {@code SyncInvoker} used to execute current request.
      * @param executorService   executor service, which should be used for executing reactive callbacks invocations.
      *                          It can be {@code null}; in that case it's up to the implementation to choose the best
      *                          {@code ExecutorService} in given environment.
      * @return instance of the {@code RxInvoker} subclass.
      */
-    public T getRxInvoker(Invocation.Builder invocationBuilder, ExecutorService executorService);
+    public T getRxInvoker(SyncInvoker syncInvoker, ExecutorService executorService);
 
 }


### PR DESCRIPTION
It needs to be registered to the client runtime and is looked up by the RxInvoker class.

Change-Id: I81ececd8c6277a4d4d52c6b8deab8ed586ed005c