### PR TITLE
corrected use of PATCH method in @PATCH

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/HttpMethod.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/HttpMethod.java
@@ -55,11 +55,14 @@ import java.lang.annotation.Target;
  *
  * @author Paul Sandoz
  * @author Marc Hadley
+ * @author Sebastian Daschner
  * @see GET
  * @see POST
  * @see PUT
  * @see DELETE
+ * @see PATCH
  * @see HEAD
+ * @see OPTIONS
  * @since 1.0
  */
 @Target({ElementType.ANNOTATION_TYPE})
@@ -83,6 +86,10 @@ public @interface HttpMethod {
      * HTTP DELETE method.
      */
     public static final String DELETE = "DELETE";
+    /**
+     * HTTP PATCH method.
+     */
+    public static final String PATCH = "PATCH";
     /**
      * HTTP HEAD method.
      */

--- a/jaxrs-api/src/main/java/javax/ws/rs/PATCH.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/PATCH.java
@@ -55,7 +55,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@HttpMethod(HttpMethod.GET)
+@HttpMethod(HttpMethod.PATCH)
 @Documented
 public @interface PATCH {
 }


### PR DESCRIPTION
The new `@PATCH` HTTP method should use "PATCH".