### PR TITLE
FIX - packaging.type property is breaking various build systems (sbt, gradle, ivy, etc.)

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -52,7 +52,7 @@
     <groupId>javax.ws.rs</groupId>
     <artifactId>javax.ws.rs-api</artifactId>
     <version>2.2-SNAPSHOT</version>
-    <packaging>${packaging.type}</packaging>
+    <packaging>jar</packaging>
     <name>javax.ws.rs-api</name>
 
     <url>http://jax-rs-spec.java.net</url>


### PR DESCRIPTION
This has been discussed here #571 and and #572. This has not been fixed - there is no workaround for sbt. PLEASE fix this as it causing a great deal of problem for users. Further, there appears to be no good reason for the change.