### PR TITLE
Added status code 308

### DIFF
--- a/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
+++ b/jaxrs-api/src/main/java/javax/ws/rs/core/Response.java
@@ -814,6 +814,21 @@ public abstract class Response implements AutoCloseable {
     public static ResponseBuilder temporaryRedirect(URI location) {
         return status(Status.TEMPORARY_REDIRECT).location(location);
     }
+    
+    /**
+     * Create a new ResponseBuilder for a permanent redirection.
+     *
+     * @param location the redirection URI. If a relative URI is
+     *                 supplied it will be converted into an absolute URI by resolving it
+     *                 relative to the base URI of the application (see
+     *                 {@link UriInfo#getBaseUri}).
+     * @return a new response builder.
+     * @throws java.lang.IllegalArgumentException
+     *          if location is {@code null}.
+     */
+    public static ResponseBuilder permanentRedirect(URI location) {
+        return status(Status.PERMANENT_REDIRECT).location(location);
+    }
 
     /**
      * Create a new ResponseBuilder for a not acceptable response.
@@ -1320,6 +1335,10 @@ public abstract class Response implements AutoCloseable {
          * 307 Temporary Redirect, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8">HTTP/1.1 documentation</a>}.
          */
         TEMPORARY_REDIRECT(307, "Temporary Redirect"),
+        /**
+         * 308 Temporary Redirect, see {@link <a href="https://tools.ietf.org/html/rfc7538">HTTP/1.1 documentation</a>}.
+         */
+        PERMANENT_REDIRECT(308, "Permanent Redirect"),
         /**
          * 400 Bad Request, see {@link <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1 documentation</a>}.
          */


### PR DESCRIPTION
*Added status code 308*

Fixes issue #573 

RFC 7538 describes the behavior of the HTTP status code 308. While this RFC is quite new it solves an actual problem regarding POST redirections.

And it completes quite well the 307 status code found in the HTTP 1.1 RFC (previously described in the obsolete RFC 2616).